### PR TITLE
Reduce mediator creation and configuration overhead

### DIFF
--- a/src/robotlegs/bender/extensions/commandCenter/impl/CommandMapping.hx
+++ b/src/robotlegs/bender/extensions/commandCenter/impl/CommandMapping.hx
@@ -147,6 +147,6 @@ class CommandMapping implements ICommandMapping
 
 	public function toString():String
 	{
-		return 'Command ' + _commandClass;
+		return 'Command ' + Type.getClassName(_commandClass);
 	}
 }

--- a/src/robotlegs/bender/extensions/contextView/ContextView.hx
+++ b/src/robotlegs/bender/extensions/contextView/ContextView.hx
@@ -14,7 +14,9 @@ import openfl.display.DisplayObjectContainer;
  */
 
 @:keepSub
-class ContextView implements org.swiftsuspenders.reflection.ITypeDescriptionAware
+class ContextView
+	implements org.swiftsuspenders.reflection.ITypeDescriptionAware
+	implements robotlegs.bender.framework.api.IConfig
 {
 	public var view:DisplayObjectContainer;
 
@@ -26,4 +28,6 @@ class ContextView implements org.swiftsuspenders.reflection.ITypeDescriptionAwar
 	{
 		this.view = view;
 	}
+	
+	public function configure() {} // because we add this to ConfigManager for some reason /shrug
 }

--- a/src/robotlegs/bender/extensions/eventCommandMap/impl/EventCommandTrigger.hx
+++ b/src/robotlegs/bender/extensions/eventCommandMap/impl/EventCommandTrigger.hx
@@ -87,7 +87,7 @@ class EventCommandTrigger implements ICommandTrigger
 
 	public function toString():String
 	{
-		return _eventClass + " with selector '" + _type + "'";
+		return (if (_eventClass == null) "null" else Type.getClassName(_eventClass)) + " with selector '" + _type + "'";
 	}
 
 	/*============================================================================*/

--- a/src/robotlegs/bender/extensions/mediatorMap/api/IMediator.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/api/IMediator.hx
@@ -12,6 +12,8 @@ package robotlegs.bender.extensions.mediatorMap.api;
  */
 interface IMediator
 {
+	var viewComponent(null, default):Dynamic;
+	
 	/**
 	 * Initializes the mediator. This is run automatically by the mediatorMap when a mediator is created.
 	 * Normally the initialize function is where you would add handlers using the eventMap.
@@ -23,4 +25,6 @@ interface IMediator
 	 * You should clean up any handlers that were added directly (eventMap handlers will be cleaned up automatically).
 	 */
 	function destroy():Void;
+
+	function postDestroy():Void;
 }

--- a/src/robotlegs/bender/extensions/mediatorMap/api/IMediatorMapping.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/api/IMediatorMapping.hx
@@ -22,7 +22,7 @@ interface IMediatorMapping
 	/**
 	 * The concrete mediator class
 	 */
-	public var mediatorClass(get, null):Class<Dynamic>;
+	public var mediatorClass(get, null):Class<IMediator>;
 	
 	/**
 	 * A list of guards to check before allowing mediator creation

--- a/src/robotlegs/bender/extensions/mediatorMap/dsl/IMediatorConfigurator.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/dsl/IMediatorConfigurator.hx
@@ -7,6 +7,8 @@
 
 package robotlegs.bender.extensions.mediatorMap.dsl;
 
+import robotlegs.bender.extensions.mediatorMap.api.IMediator;
+
 /**
  * Configures a mediator mapping
  */

--- a/src/robotlegs/bender/extensions/mediatorMap/dsl/IMediatorMapper.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/dsl/IMediatorMapper.hx
@@ -7,6 +7,8 @@
 
 package robotlegs.bender.extensions.mediatorMap.dsl;
 
+import robotlegs.bender.extensions.mediatorMap.api.IMediator;
+
 /**
  * Maps a matcher to a concrete Mediator class
  */
@@ -17,5 +19,5 @@ interface IMediatorMapper
 	 * @param mediatorClass The concrete mediator class
 	 * @return Mapping configurator
 	 */
-	function toMediator(mediatorClass:Class<Dynamic>):IMediatorConfigurator;
+	function toMediator(mediatorClass:Class<IMediator>):IMediatorConfigurator;
 }

--- a/src/robotlegs/bender/extensions/mediatorMap/dsl/IMediatorUnmapper.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/dsl/IMediatorUnmapper.hx
@@ -7,6 +7,8 @@
 
 package robotlegs.bender.extensions.mediatorMap.dsl;
 
+import robotlegs.bender.extensions.mediatorMap.api.IMediator;
+
 /**
  * Unmaps a Mediator
  */
@@ -16,7 +18,7 @@ interface IMediatorUnmapper
 	 * Unmaps a mediator from this matcher
 	 * @param mediatorClass Mediator to unmap
 	 */
-	function fromMediator(mediatorClass:Class<Dynamic>):Void;
+	function fromMediator(mediatorClass:Class<IMediator>):Void;
 
 	/**
 	 * Unmaps all mediator mappings for this matcher

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorManager.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorManager.hx
@@ -10,7 +10,7 @@ package robotlegs.bender.extensions.mediatorMap.impl;
 import openfl.display.DisplayObject;
 import openfl.events.Event;
 import org.swiftsuspenders.utils.CallProxy;
-//import flash.utils.getDefinitionByName;
+import robotlegs.bender.extensions.mediatorMap.api.IMediator;
 import robotlegs.bender.extensions.mediatorMap.api.IMediatorMapping;
 
 /**
@@ -20,17 +20,6 @@ import robotlegs.bender.extensions.mediatorMap.api.IMediatorMapping;
 @:keepSub
 class MediatorManager
 {
-
-	/*============================================================================*/
-	/* Private Static Properties                                                  */
-	/*============================================================================*/
-
-	private static var UIComponentClass:Class<Dynamic>;
-
-	private static var flexAvailable:Bool = false;// checkFlex();
-
-	public static var CREATION_COMPLETE:String = "creationComplete";
-
 	/*============================================================================*/
 	/* Private Properties                                                         */
 	/*============================================================================*/
@@ -50,30 +39,13 @@ class MediatorManager
 	}
 
 	/*============================================================================*/
-	/* Private Static Functions                                                   */
-	/*============================================================================*/
-
-	/*private static function checkFlex():Bool
-	{
-		try
-		{
-			UIComponentClass = cast(getDefinitionByName('mx.core::UIComponent'), Class<Dynamic>);
-		}
-		catch (error:Error)
-		{
-			// Do nothing
-		}
-		return UIComponentClass != null;
-	}*/
-
-	/*============================================================================*/
 	/* Public Functions                                                           */
 	/*============================================================================*/
 
 	/**
 	 * @private
 	 */
-	public function addMediator(mediator:Dynamic, item:Dynamic, mapping:IMediatorMapping):Void
+	public function addMediator(mediator:IMediator, item:Dynamic, mapping:IMediatorMapping):Void
 	{
 		var displayObject:DisplayObject = null;
 		if (Std.is(item, DisplayObject)) {
@@ -85,27 +57,18 @@ class MediatorManager
 			displayObject.addEventListener(Event.REMOVED_FROM_STAGE, onRemovedFromStage);
 
 		// Synchronize with item life-cycle
-		if (itemInitialized(item))
-		{
-			initializeMediator(mediator, item);
-		}
-		else
-		{
-			var mediatorManagerAddMediator:MediatorManagerAddMediator = new MediatorManagerAddMediator(initializeMediator, _factory, displayObject, mediator, item, mapping);
-			displayObject.addEventListener(MediatorManager.CREATION_COMPLETE, mediatorManagerAddMediator.creationComplete);
-		}
+		initializeMediator(mediator, item);
 	}
 	
 	/**
 	 * @private
 	 */
-	public function removeMediator(mediator:Dynamic, item:Dynamic, mapping:IMediatorMapping):Void
+	public function removeMediator(mediator:IMediator, item:Dynamic, mapping:IMediatorMapping):Void
 	{
 		if (Std.is(item, DisplayObject))
 			cast(item, DisplayObject).removeEventListener(Event.REMOVED_FROM_STAGE, onRemovedFromStage);
 
-		if (itemInitialized(item))
-			destroyMediator(mediator);
+		destroyMediator(mediator);
 	}
 
 	/*============================================================================*/
@@ -117,70 +80,16 @@ class MediatorManager
 		_factory.removeMediators(event.target);
 	}
 
-	private function itemInitialized(item:Dynamic):Bool
+	private function initializeMediator(mediator:IMediator, mediatedItem:Dynamic):Void
 	{
-		if (flexAvailable && (Std.is(item, UIComponentClass)) && !CallProxy.hasField(item, 'initialized'))
-			return false;
-		return true;
+		mediator.viewComponent = mediatedItem;
+		mediator.initialize();
 	}
 
-	private function initializeMediator(mediator:Dynamic, mediatedItem:Dynamic):Void
+	private function destroyMediator(mediator:IMediator):Void
 	{
-		if (CallProxy.hasField(mediator, 'preInitialize'))
-			mediator.preInitialize();
-
-		if (CallProxy.hasField(mediator, 'viewComponent'))
-			mediator.viewComponent = mediatedItem;
-
-		if (CallProxy.hasField(mediator, 'initialize'))
-			mediator.initialize();
-
-		if (CallProxy.hasField(mediator, 'postInitialize'))
-			mediator.postInitialize();
-	}
-
-	private function destroyMediator(mediator:Dynamic):Void
-	{
-		if (CallProxy.hasField(mediator, 'preDestroy'))
-			mediator.preDestroy();
-
-		if (CallProxy.hasField(mediator, 'destroy'))
-			mediator.destroy();
-
-		if (CallProxy.hasField(mediator, 'viewComponent'))
-			mediator.viewComponent = null;
-
-		if (CallProxy.hasField(mediator, 'postDestroy'))
-			mediator.postDestroy();
-	}
-}
-
-@:keepSub
-class MediatorManagerAddMediator
-{
-	var displayObject:DisplayObject;
-	var mediator:Dynamic;
-	var item:Dynamic;
-	var mapping:IMediatorMapping;
-	var _factory:MediatorFactory;
-	var initializeMediator:Dynamic;
-	
-	public function new(initializeMediator:Dynamic -> Dynamic -> Void, _factory:MediatorFactory, displayObject:DisplayObject, mediator:Dynamic, item:Dynamic, mapping:IMediatorMapping)
-	{
-		this.initializeMediator = initializeMediator;
-		this._factory = _factory;
-		this.mapping = mapping;
-		this.item = item;
-		this.mediator = mediator;
-		this.displayObject = displayObject;
-	}
-	
-	public function creationComplete(e:Event):Void 
-	{
-		displayObject.removeEventListener(MediatorManager.CREATION_COMPLETE, creationComplete);
-		// Ensure that we haven't been removed in the meantime
-		if (_factory.getMediator(item, mapping) == mediator) {
-			initializeMediator(mediator, item);
-		}
+		mediator.destroy();
+		mediator.viewComponent = null;
+		mediator.postDestroy();
 	}
 }

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorMapper.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorMapper.hx
@@ -11,6 +11,7 @@ package robotlegs.bender.extensions.mediatorMap.impl;
 import org.swiftsuspenders.InjectorMacro;
 import org.swiftsuspenders.utils.UID;
 import robotlegs.bender.extensions.matching.ITypeFilter;
+import robotlegs.bender.extensions.mediatorMap.api.IMediator;
 import robotlegs.bender.extensions.mediatorMap.api.IMediatorMapping;
 import robotlegs.bender.extensions.mediatorMap.dsl.IMediatorConfigurator;
 import robotlegs.bender.extensions.mediatorMap.dsl.IMediatorMapper;
@@ -29,7 +30,7 @@ class MediatorMapper implements IMediatorMapper implements IMediatorUnmapper
 	/* Private Properties                                                         */
 	/*============================================================================*/
 
-	private var _mappings = new Map<String,Dynamic>();
+	private var _mappings = new Map<String,IMediatorMapping>();
 
 	private var _typeFilter:ITypeFilter;
 
@@ -58,10 +59,10 @@ class MediatorMapper implements IMediatorMapper implements IMediatorUnmapper
 	/**
 	 * @inheritDoc
 	 */
-	public function toMediator(mediatorClass:Class<Dynamic>):IMediatorConfigurator
+	public function toMediator(mediatorClass:Class<IMediator>):IMediatorConfigurator
 	{
 		InjectorMacro.keep(mediatorClass);
-		var mapping:IMediatorMapping = _mappings[UID.classID(mediatorClass)];
+		var mapping = _mappings[Type.getClassName(mediatorClass)];
 		return (mapping != null)
 			? overwriteMapping(mapping)
 			: createMapping(mediatorClass);
@@ -70,9 +71,9 @@ class MediatorMapper implements IMediatorMapper implements IMediatorUnmapper
 	/**
 	 * @inheritDoc
 	 */
-	public function fromMediator(mediatorClass:Class<Dynamic>):Void
+	public function fromMediator(mediatorClass:Class<IMediator>):Void
 	{
-		var mapping:IMediatorMapping = _mappings[UID.classID(mediatorClass)];
+		var mapping = _mappings[Type.getClassName(mediatorClass)];
 		if (mapping != null) deleteMapping(mapping);
 	}
 
@@ -91,11 +92,11 @@ class MediatorMapper implements IMediatorMapper implements IMediatorUnmapper
 	/* Private Functions                                                          */
 	/*============================================================================*/
 
-	private function createMapping(mediatorClass:Class<Dynamic>):MediatorMapping
+	private function createMapping(mediatorClass:Class<IMediator>):MediatorMapping
 	{
-		var mapping:MediatorMapping = new MediatorMapping(_typeFilter, mediatorClass);
+		var mapping = new MediatorMapping(_typeFilter, mediatorClass);
 		_handler.addMapping(mapping);
-		_mappings[UID.classID(mediatorClass)] = mapping;
+		_mappings[Type.getClassName(mediatorClass)] = mapping;
 		if (_logger != null) _logger.debug('{0} mapped to {1}', [_typeFilter, mapping]);
 		return mapping;
 	}
@@ -103,7 +104,7 @@ class MediatorMapper implements IMediatorMapper implements IMediatorUnmapper
 	private function deleteMapping(mapping:IMediatorMapping):Void
 	{
 		_handler.removeMapping(mapping);
-		_mappings.remove(UID.classID(mapping.mediatorClass));
+		_mappings.remove(Type.getClassName(mapping.mediatorClass));
 		if (_logger != null) _logger.debug('{0} unmapped from {1}', [_typeFilter, mapping]);
 	}
 

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorMapping.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorMapping.hx
@@ -8,6 +8,7 @@
 package robotlegs.bender.extensions.mediatorMap.impl;
 
 import robotlegs.bender.extensions.matching.ITypeFilter;
+import robotlegs.bender.extensions.mediatorMap.api.IMediator;
 import robotlegs.bender.extensions.mediatorMap.api.IMediatorMapping;
 import robotlegs.bender.extensions.mediatorMap.dsl.IMediatorConfigurator;
 
@@ -27,8 +28,8 @@ class MediatorMapping implements IMediatorMapping implements IMediatorConfigurat
 	   return matcher;
 	}
 	
-	public var mediatorClass(get, null):Class<Dynamic>;
-	function get_mediatorClass():Class<Dynamic>
+	public var mediatorClass(get, null):Class<IMediator>;
+	function get_mediatorClass():Class<IMediator>
 	{
 		return mediatorClass;
 	}
@@ -58,7 +59,7 @@ class MediatorMapping implements IMediatorMapping implements IMediatorConfigurat
 	/**
 	 * @private
 	 */
-	public function new(matcher:ITypeFilter, mediatorClass:Class<Dynamic>)
+	public function new(matcher:ITypeFilter, mediatorClass:Class<IMediator>)
 	{
 		this.matcher = matcher;
 		this.mediatorClass = mediatorClass;

--- a/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorViewHandler.hx
+++ b/src/robotlegs/bender/extensions/mediatorMap/impl/MediatorViewHandler.hx
@@ -25,7 +25,7 @@ class MediatorViewHandler implements IViewHandler
 	/* Private Properties                                                         */
 	/*============================================================================*/
 
-	private var _mappings:Array<Dynamic> = [];
+	private var _mappings:Array<IMediatorMapping> = [];
 
 	private var _knownMappings = new Map<String,Array<IMediatorMapping>>();
 
@@ -76,7 +76,7 @@ class MediatorViewHandler implements IViewHandler
 	 */
 	public function handleView(view:DisplayObject, type:Class<Dynamic>):Void
 	{
-		var interestedMappings:Array<Dynamic> = getInterestedMappingsFor(view, type);
+		var interestedMappings = getInterestedMappingsFor(view, type);
 		if (interestedMappings != null)
 			_factory.createMediators(view, type, interestedMappings);
 	}
@@ -86,7 +86,7 @@ class MediatorViewHandler implements IViewHandler
 	 */
 	public function handleItem(item:Dynamic, type:Class<Dynamic>):Void
 	{
-		var interestedMappings:Array<Dynamic> = getInterestedMappingsFor(item, type);
+		var interestedMappings = getInterestedMappingsFor(item, type);
 		if (interestedMappings != null)
 			_factory.createMediators(item, type, interestedMappings);
 	}
@@ -102,31 +102,32 @@ class MediatorViewHandler implements IViewHandler
 
 	private function getInterestedMappingsFor(item:Dynamic, type:Class<Dynamic>):Array<IMediatorMapping>
 	{
-		var mapping:IMediatorMapping;
-		var typeID = UID.classID(type);
+		var typeID = Type.getClassName(type);
+		
+		var knownMappings = _knownMappings.get(typeID);
 		
 		// we've seen this type before and nobody was interested
-		if (_knownMappings.exists(typeID) && _knownMappings.get(typeID).length == 0)
+		if (knownMappings != null && knownMappings.length == 0)
 			return null;
 
 		// we haven't seen this type before
-		if (!_knownMappings.exists(typeID))
+		if (knownMappings == null)
 		{
-			_knownMappings.set(typeID, []);
-			for (i in 0..._mappings.length)
+			knownMappings = [];
+			_knownMappings.set(typeID, knownMappings);
+			for (mapping in _mappings)
 			{
-				mapping = _mappings[i];
 				if (mapping.matcher.matches(item))
 				{
-					_knownMappings.get(typeID).push(mapping);
+					knownMappings.push(mapping);
 				}
 			}
 			// nobody cares, let's get out of here
-			if (_knownMappings.get(typeID).length == 0)
+			if (knownMappings.length == 0)
 				return null;
 		}
 
 		// these mappings really do care
-		return _knownMappings.get(typeID);
+		return knownMappings;
 	}
 }

--- a/src/robotlegs/bender/extensions/viewManager/impl/ContainerBinding.hx
+++ b/src/robotlegs/bender/extensions/viewManager/impl/ContainerBinding.hx
@@ -108,10 +108,8 @@ class ContainerBinding extends EventDispatcher
 	 */
 	public function handleView(view:DisplayObject, type:Class<Dynamic>):Void
 	{
-		var length:UInt = _handlers.length;
-		for (i in 0...length)
+		for (handler in _handlers)
 		{
-			var handler:IViewHandler = cast(_handlers[i], IViewHandler);
 			handler.handleView(view, type);
 		}
 	}

--- a/src/robotlegs/bender/extensions/viewProcessorMap/impl/ViewProcessorViewHandler.hx
+++ b/src/robotlegs/bender/extensions/viewProcessorMap/impl/ViewProcessorViewHandler.hx
@@ -102,7 +102,7 @@ class ViewProcessorViewHandler implements IViewProcessorViewHandler
 	private function getInterestedMappingsFor(view:Dynamic, type:Class<Dynamic>):Array<IViewProcessorMapping>
 	{
 		var mapping:IViewProcessorMapping;
-		var id = UID.classID(type);
+		var id = Type.getClassName(type);
 
 		// we've seen this type before and nobody was interested
 		if (_interestedMappings[id] == false) {

--- a/src/robotlegs/bender/framework/api/IContext.hx
+++ b/src/robotlegs/bender/framework/api/IContext.hx
@@ -7,6 +7,7 @@
 
 package robotlegs.bender.framework.api;
 
+import haxe.extern.EitherType;
 import openfl.events.IEventDispatcher;
 
 @:meta(Event(name="destroy", type="robotlegs.bender.framework.api.LifecycleEvent"))
@@ -88,7 +89,7 @@ interface IContext extends IEventDispatcher
 	 * @param configs Configuration objects or classes of any type
 	 * @return this
 	 */
-	function configure(configs:Dynamic):IContext;
+	function configure(config:EitherType<IConfig,Class<IConfig>>):IContext;
 
 	/**
 	 * Adds an uninitialized context as a child

--- a/src/robotlegs/bender/framework/impl/ConfigManager.hx
+++ b/src/robotlegs/bender/framework/impl/ConfigManager.hx
@@ -7,6 +7,7 @@
 
 package robotlegs.bender.framework.impl;
 
+import haxe.extern.EitherType;
 import haxe.ds.ObjectMap;
 import openfl.errors.Error;
 import org.swiftsuspenders.utils.CallProxy;
@@ -77,7 +78,7 @@ class ConfigManager
 	 * <p>If the manager is not initialized the configuration will be queued.</p>
 	 * @param config The configuration object or class
 	 */
-	public function addConfig(config:Dynamic):Void
+	public function addConfig(config:EitherType<IConfig,Class<IConfig>>):Void
 	{
 		if (!_configs.exists(config))
 		{
@@ -123,7 +124,7 @@ class ConfigManager
 		}
 	}
 
-	private function handleClass(type:Class<Dynamic>):Void
+	private function handleClass(type:Class<IConfig>):Void
 	{
 		if (_initialized)
 		{
@@ -137,7 +138,7 @@ class ConfigManager
 		}
 	}
 
-	private function handleObject(object:Dynamic):Void
+	private function handleObject(object:IConfig):Void
 	{
 		if (_initialized)
 		{
@@ -163,7 +164,7 @@ class ConfigManager
 					_logger.debug("Now initializing. Instantiating config class {0}", [config]);
 				#end
 				
-				processClass(cast(config, Class<Dynamic>));
+				processClass(config);
 			}
 			else
 			{
@@ -179,53 +180,27 @@ class ConfigManager
 		_queue = [];
 	}
 
-	private function processClass(type:Class<Dynamic>):Void
+	private function processClass(type:Class<IConfig>):Void
 	{
 		//var config = cast(_injector.getOrCreateNewInstance(type), IConfig);
 		// CHECK
 		//config && config.configure();
 		//if (config != null) config.configure();
 		
-		var object = _injector.getOrCreateNewInstance(type);
+		var object:IConfig = _injector.getOrCreateNewInstance(type);
 		
 		//catch (e:Error) {
 		//	throw new Error("Can't cast " + type + " to IConfig, check you are using the @:keepSub meta tag");
 		//}
 		
 		if (object != null) {
-			
-			
-			var className = Type.getClassName(type);
-			var hasFeild = CallProxy.hasField(object, "configure");
-			if (hasFeild) {
-				#if js
-					untyped __js__("object['configure']();");
-				#else 
-					var func = Reflect.getProperty(object, "configure");
-					if (func != null) func();
-				#end
-			}
+			object.configure();
 		}
 	}
 
-	private function processObject(object:Dynamic):Void
+	private function processObject(object:IConfig):Void
 	{
 		_injector.injectInto(object);
-		//var config = cast(object, IConfig);
-		
-		//config && config.configure();
-		//if (config != null) config.configure();
-		// CHECK
-		var hasFeild = CallProxy.hasField(object, "configure");
-		if (hasFeild) {
-			#if js
-				
-				untyped __js__("object['configure']();");
-			#else 
-				var func = Reflect.getProperty(object, "configure");
-				if (func != null) func();
-			#end
-		}
-		
+		object.configure();
 	}
 }

--- a/src/robotlegs/bender/framework/impl/Context.hx
+++ b/src/robotlegs/bender/framework/impl/Context.hx
@@ -7,8 +7,11 @@
 
 package robotlegs.bender.framework.impl;
 
+import haxe.extern.EitherType;
+
 import openfl.events.EventDispatcher;
 import org.swiftsuspenders.utils.UID;
+import robotlegs.bender.framework.api.IConfig;
 import robotlegs.bender.framework.api.IContext;
 import robotlegs.bender.framework.api.IInjector;
 import robotlegs.bender.framework.api.ILogTarget;
@@ -328,29 +331,10 @@ class Context extends EventDispatcher implements IContext
 	/**
 	 * @inheritDoc
 	 */
-	public function configure(configs:Dynamic):IContext
+	public function configure(config:EitherType<IConfig,Class<IConfig>>):IContext
 	{
-		if (Std.is(configs, Array)) {
-			var configsArray:Array<Dynamic> = cast(configs);
-			for (config in configsArray)
-			{
-				configureObject(config);
-			}
-		}
-		else {
-			configureObject(configs);
-		}
-		return this;
-	}
-	
-	private function configureObject(config:Dynamic):Void
-	{
-		#if (js)
-			if (!Std.is(config, Class)) {
-				Reflect.setProperty(config, "constructor", Type.getClass(config));
-			}
-		#end
 		_configManager.addConfig(config);
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
This removes "run-time duck-typing" usage when creating mediators in favor of just using `IMediator`. 

This actually removes support for some pre/post initialize/destroy methods for mediators that were not present in the `IMediator` interface, but it was not used by Elvenar anyway, so it should be fine.

Also do similar thing for configuration objects - use `IConfig` instead.